### PR TITLE
Fix path for Babel config

### DIFF
--- a/backend/jest.config.mjs
+++ b/backend/jest.config.mjs
@@ -11,7 +11,7 @@ export default {
 
   // Configure transform for ES modules
   transform: {
-    '^.+\\.m?js$': ['babel-jest', { configFile: './babel.config.json' }],
+    '^.+\\.m?js$': ['babel-jest', { configFile: './babel.config.mjs' }],
   },
 
   // Don't transform node_modules except for specific packages that need it


### PR DESCRIPTION
## Summary
- point jest config at `babel.config.mjs`

## Testing
- `npm run test-backend` *(fails: SyntaxError - Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_683fc40cce208325b767240b0d324d53